### PR TITLE
Added: Backup capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ saleor_storefront
 charts/saleor-platform/charts
 charts/saleor-platform/tmpcharts
 charts/saleor-platform/Chart.lock
+charts/saleor-platform/ChartBak.yaml
+chart-releaser_*
 downloads
 *-x86_64
 index.yaml

--- a/charts/saleor-core/Chart.yaml
+++ b/charts/saleor-core/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 name: saleor-core
 description: A Helm chart for deploying the saleor core application in Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 2.11.4
 kubeVersion: ">=1.9.0"
 keywords:

--- a/charts/saleor-core/config/backup.sh
+++ b/charts/saleor-core/config/backup.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2086,SC2153
+
+set -eo pipefail
+
+export AWS_ACCESS_KEY_ID="${RESTIC_S3_ACCESS_KEY_ID}"
+export AWS_SECRET_ACCESS_KEY="${RESTIC_S3_SECRET_ACCESS_KEY}"
+export AWS_DEFAULT_REGION="${RESTIC_S3_REGION}"
+
+function try_restic_initialization() {
+    local restic_global_args=${1}
+    local restic_host=${2}
+
+    if [[ -z "${restic_host}" ]]; then
+        echo "Variable restic_host is required, exiting"
+        exit 1
+    fi
+
+    restic snapshots ${restic_global_args} --host ${restic_host} ||
+        (
+            echo "Initializing the restic repository" &&
+                restic init ${restic_global_args}
+        ) &&
+        (
+            echo "The restic repository has already been initialized"
+        )
+}
+
+function init() {
+    if [[ -z "${RESTIC_REPOSITORY}" ]]; then
+        echo "Environment variable RESTIC_REPOSITORY not set, exiting"
+        exit 1
+    fi
+
+    if [[ -z "${RESTIC_S3_REGION}" ]]; then
+        echo "Environment variable RESTIC_S3_REGION not set, exiting"
+        exit 1
+    fi
+
+    if [[ -z "${RESTIC_PASSWORD}" ]]; then
+        echo "Environment variable RESTIC_PASSWORD not set, exiting"
+        exit 1
+    fi
+
+    if [[ -z "${RESTIC_S3_ACCESS_KEY_ID}" ]]; then
+        echo "Environment variable RESTIC_S3_ACCESS_KEY_ID not set, exiting"
+        exit 1
+    fi
+
+    if [[ -z "${RESTIC_S3_SECRET_ACCESS_KEY}" ]]; then
+        echo "Environment variable RESTIC_S3_SECRET_ACCESS_KEY not set, exiting"
+        exit 1
+    fi
+
+    if [[ -z "${RESTIC_HOST}" ]]; then
+        echo "Environment variable RESTIC_HOST not set, exiting"
+        exit 1
+    fi
+
+    if [[ -z "${RESTIC_GLOBAL_ARGS}" ]]; then
+        try_restic_initialization --host "${RESTIC_HOST}"
+    else
+        try_restic_initialization "${RESTIC_GLOBAL_ARGS}" --host "${RESTIC_HOST}"
+    fi
+}
+
+function execute_pg_dump() {
+    local postgresql_password=${1}
+    local postgresql_host=${2}
+    local postgresql_port=${3}
+    local postgresql_user=${4}
+    local postgresql_database=${5}
+    local postgresql_additional_args=${6}
+
+    if [[ ! -d /home/saleor/backups/database ]]; then
+        mkdir -p /home/saleor/backups/database
+    fi
+
+    echo "Dumping postgresql database with the following arguments:"
+    echo "host: ${postgresql_host}"
+    echo "port: ${postgresql_port}"
+    echo "username: ${postgresql_user}"
+    echo "dbname: ${postgresql_database}"
+
+    if [[ -z "${postgresql_additional_args}" ]]; then
+        PGPASSWORD="${postgresql_password}" \
+            pg_dump \
+            --verbose \
+            --host="${postgresql_host}" \
+            --port="${postgresql_port}" \
+            --username="${postgresql_user}" \
+            --dbname="${postgresql_database}" \
+            --no-password >/home/saleor/backups/database/saleor-core-postgresql.dump
+    else
+        echo "additional arguments: ${postgresql_additional_args}"
+        PGPASSWORD="${postgresql_password}" \
+            pg_dump \
+            ${postgresql_additional_args} \
+            --host="${postgresql_host}" \
+            --port="${postgresql_port}" \
+            --username="${postgresql_user}" \
+            --dbname="${postgresql_database}" \
+            --no-password >/home/saleor/backups/database/saleor-core-postgresql.dump
+    fi &&
+        echo "Finished pg_dump successfully" ||
+        echo "Finished pg_dump unsuccessfuly"
+}
+
+function restic_save_db() {
+    local restic_global_args=${1}
+    local restic_host=${2}
+
+    restic backup \
+        ${restic_global_args} \
+        --host "${restic_host}-db" \
+        /home/saleor/backups/database/saleor-core-postgresql.dump &&
+        echo "Saved media backup via restic tool successfully" ||
+        echo "Saved media backup via restic tool unsuccessfully"
+}
+
+function restic_save_media() {
+    local restic_global_args=${1}
+    local restic_host=${2}
+
+    restic backup \
+        ${restic_global_args} \
+        --host "${restic_host}-media" \
+        /app/media &&
+        echo "Saved media backup via restic tool successfully" ||
+        echo "Saved media backup via restic tool unsuccessfully"
+}
+
+function display_snapshots() {
+    restic snapshots --verbose --no-cache
+}
+
+function main() {
+    local do_postgresql_backup=${1}
+    local postgresql_password=${2}
+    local postgresql_host=${3}
+    local postgresql_port=${4}
+    local postgresql_user=${5}
+    local postgresql_database=${6}
+    local postgresql_additional_args=${7}
+    local do_media_backup=${8}
+    local restic_global_args=${9}
+    local restic_host=${10}
+
+    init
+
+    if [[ "${do_postgresql_backup}" == "true" ]]; then
+        echo "Postgresql backup is to be executed"
+
+        execute_pg_dump \
+            "${postgresql_password}" \
+            "${postgresql_host}" \
+            "${postgresql_port}" \
+            "${postgresql_user}" \
+            "${postgresql_database}" \
+            "${postgresql_additional_args}"
+    fi
+    if [[ "${do_media_backup}" == "true" ]]; then
+        echo "Saving media files using restic"
+
+        restic_save_media \
+            "${restic_global_args}" \
+            "${restic_host}"
+    fi
+    if [[ "${do_postgresql_backup}" == "true" ]]; then
+        echo "Saving postgresql backup using restic"
+
+        restic_save_db \
+            "${restic_global_args}" \
+            "${restic_host}"
+    fi
+
+    display_snapshots
+}
+
+main "${@}"

--- a/charts/saleor-core/templates/_helpers.tpl
+++ b/charts/saleor-core/templates/_helpers.tpl
@@ -107,6 +107,12 @@ env:
 {{- if .Values.existingSecret }}
   - name: SECRET_KEY
     value: "$(SALEOR_SECRET_KEY)"
+  - name: RESTIC_PASSWORD
+    value: ""
+  - name: RESTIC_S3_ACCESS_KEY_ID
+    value: ""
+  - name: RESTIC_S3_SECRET_ACCESS_KEY
+    value: ""
 {{- end }}
 {{- if and .Values.jobs.init.plugins.enabled .Values.externalServices.vatLayer.enabled }}
   - name: VATLAYER_API_KEY
@@ -154,6 +160,42 @@ env:
 {{- else if $smtp.amazonSES.enabled }}
   - name: EMAIL_URL
     value: "smtp://{{ $smtp.amazonSES.username }}:$(EMAIL_PASSWORD)@email-smtp.{{ $smtp.amazonSES.region }}.amazonaws.com:587/?tls=True"
+{{- end }}
+{{- end }}
+
+
+{{/*
+Generate backup configuration
+*/}}
+{{- define "saleor-core.env.backup" -}}
+{{- if or .Values.backup.database.enabled .Values.backup.media.enabled }}
+  - name: RESTIC_PASSWORD
+    valueFrom:
+      secretKeyRef:
+      {{- if not .Values.existingSecret }}
+        name: {{ include "saleor-core.fullname" . }}
+      {{- else }}
+        name: {{ .Values.existingSecret }}
+      {{- end }}
+        key: RESTIC_PASSWORD
+  - name: RESTIC_S3_ACCESS_KEY_ID
+    valueFrom:
+      secretKeyRef:
+      {{- if not .Values.existingSecret }}
+        name: {{ include "saleor-core.fullname" . }}
+      {{- else }}
+        name: {{ .Values.existingSecret }}
+      {{- end }}
+        key: RESTIC_S3_ACCESS_KEY_ID
+  - name: RESTIC_S3_SECRET_ACCESS_KEY
+    valueFrom:
+      secretKeyRef:
+      {{- if not .Values.existingSecret }}
+        name: {{ include "saleor-core.fullname" . }}
+      {{- else }}
+        name: {{ .Values.existingSecret }}
+      {{- end }}
+        key: RESTIC_S3_SECRET_ACCESS_KEY
 {{- end }}
 {{- end }}
 

--- a/charts/saleor-core/templates/backup/backup-cronjob.yaml
+++ b/charts/saleor-core/templates/backup/backup-cronjob.yaml
@@ -1,0 +1,79 @@
+{{- if and .Values.backup.cron.enabled (or .Values.backup.database.enabled .Values.backup.media.enabled) }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ include "saleor-core.fullname" . }}-backup-cronjob
+spec:
+  schedule: {{ .Values.backup.cron.schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
+          serviceAccountName: {{ include "saleor-core.serviceAccountName" . }}
+          automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+          securityContext:
+            {{- toYaml .Values.backup.podSecurityContext | nindent 12 }}
+          volumes:
+            # Volume for the images and unstructured data
+            - name: saleor-data-media
+            {{- if and .Values.persistence.enabled .Values.persistence.existingPvc }}
+            persistentVolumeClaim:
+              claimName: {{ .Values.persistence.existingPvc }}
+            {{- else if .Values.persistence.enabled }}
+            persistentVolumeClaim:
+              claimName: {{ default (include "saleor-core.fullname" .) }}
+            {{- else }}
+            emptyDir:
+              medium: Memory
+            {{- end }}
+            # ConfigMap for the backup script
+            - name: backup
+              configMap:
+                name: {{ include "saleor-core.fullname" . }}-backup
+          initContainers:
+            # Wait for successful response from postgresql
+              - name: "{{ include "saleor-core.fullname" . }}-backup-cronjob-init"
+              securityContext:
+                {{- toYaml .Values.backup.containerSecurityContext | nindent 12 }}
+              {{- include "saleor-core.env" . | indent 10 }}
+              image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag | default (cat "dev-" .Chart.AppVersion) | nospace }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command:
+                - /bin/bash
+                - -c
+                - >
+                  {{ include "saleor.postgresql.isReady" . | nindent 14 }}
+          containers:
+            - name: "{{ include "saleor-core.fullname" . }}-backup-cronjob"
+              volumeMounts:
+                - name: saleor-data-media
+                  mountPath: /app/media
+                - name: backup
+                  mountPath: /home/saleor/backup.sh
+                  subPath: backup.sh
+                  readOnly: true
+              securityContext:
+                {{- toYaml .Values.backup.containerSecurityContext | nindent 12 }}
+              {{- include "saleor-core.env" . | indent 10 }}
+              {{- include "saleor-core.env.backup" . | indent 10 }}
+              image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag | default (cat "dev-" .Chart.AppVersion) | nospace }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command:
+                - /bin/bash
+                - /home/saleor/backup.sh
+              args:
+                - 'true'
+                - '$(POSTGRESQL_PASSWORD)'
+                - '$(POSTGRESQL_HOST)'
+                - '$(POSTGRESQL_PORT)'
+                - '$(POSTGRESQL_USER)'
+                - '$(POSTGRESQL_DATABASE)'
+                - '$(POSTGRESQL_ADDITIONAL_ARGS)'
+                - 'true'
+                - '$(RESTIC_GLOBAL_ARGS)'
+                - '$(RESTIC_HOST)'
+{{- end }}

--- a/charts/saleor-core/templates/backup/backup-job.yaml
+++ b/charts/saleor-core/templates/backup/backup-job.yaml
@@ -1,0 +1,83 @@
+{{- if and .Values.executeBackupJob (or .Values.backup.database.enabled .Values.backup.media.enabled) }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "saleor-core.fullname" . }}-backup-job
+  namespace: {{ .Release.Namespace }}
+spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 1200
+  ttlSecondsAfterFinished: 2400
+  parallelism: 1
+  completions: 1
+  template:
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "saleor-core.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+      securityContext:
+        {{- toYaml .Values.backup.podSecurityContext | nindent 12 }}
+      volumes:
+        # Volume for the images and unstructured data
+        - name: saleor-data-media
+        {{- if and .Values.persistence.enabled .Values.persistence.existingPvc }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingPvc }}
+        {{- else if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ default (include "saleor-core.fullname" .) }}
+        {{- else }}
+          emptyDir:
+            medium: Memory
+        {{- end }}
+        # ConfigMap for the backup script
+        - name: backup
+          configMap:
+            name: {{ include "saleor-core.fullname" . }}-backup
+      initContainers:
+        # Wait for successful response from postgresql
+        - name: "{{ include "saleor-core.fullname" . }}-backup-job-init"
+          securityContext:
+            {{- toYaml .Values.backup.containerSecurityContext | nindent 12 }}
+          {{- include "saleor-core.env" . | indent 10 }}
+          image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag | default (cat "dev-" .Chart.AppVersion) | nospace }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/bash
+            - -c
+            - >
+              {{ include "saleor.postgresql.isReady" . | nindent 14 }}
+      containers:
+        - name: "{{ include "saleor-core.fullname" . }}-backup-job"
+          volumeMounts:
+            - name: saleor-data-media
+              mountPath: /app/media
+            - name: backup
+              mountPath: /home/saleor/backup.sh
+              subPath: backup.sh
+              readOnly: true
+          securityContext:
+            {{- toYaml .Values.backup.containerSecurityContext | nindent 12 }}
+          {{- include "saleor-core.env" . | indent 10 }}
+          {{- include "saleor-core.env.backup" . | indent 10 }}
+          image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag | default (cat "dev-" .Chart.AppVersion) | nospace }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/bash
+            - /home/saleor/backup.sh
+          args:
+            - 'true'
+            - '$(POSTGRESQL_PASSWORD)'
+            - '$(POSTGRESQL_HOST)'
+            - '$(POSTGRESQL_PORT)'
+            - '$(POSTGRESQL_USER)'
+            - '$(POSTGRESQL_DATABASE)'
+            - '$(POSTGRESQL_ADDITIONAL_ARGS)'
+            - 'true'
+            - '$(RESTIC_GLOBAL_ARGS)'
+            - '$(RESTIC_HOST)'
+      restartPolicy: Never
+{{- end }}

--- a/charts/saleor-core/templates/configmap-env.yaml
+++ b/charts/saleor-core/templates/configmap-env.yaml
@@ -13,12 +13,12 @@
 {{- $tls_hosts := $tls.hosts | join  "," }}
 
 # Collect all types of ingress hosts into a deduplicated list
-{{- $ingress_hosts := cat $http_hosts $tls_hosts | replace " " "," | splitList "," | uniq | join "," | trimAll "," }}
+{{- $ingress_hosts := printf "%v,%v" $http_hosts $tls_hosts | splitList "," | uniq | join "," | trimAll "," }}
 {{- $ingress_hosts_client := $ingress_hosts | replace "core." "" }}
 
 # Collect values hosts and ingress hosts into a deduplicated list
-{{- $allowed_hosts := empty .Values.allowedHosts.hosts | ternary "" (cat (.Values.allowedHosts.hosts | join "," | trimAll ",") $ingress_hosts | replace " " "," | splitList "," | uniq | join ",") }}
-{{- $all_hosts := empty $allowed_hosts | ternary $ingress_hosts (cat $allowed_hosts $ingress_hosts | replace " " "," | splitList "," | uniq | join ",") }}
+{{- $allowed_hosts := empty .Values.allowedHosts.hosts | ternary "" (printf "%v,%v" (.Values.allowedHosts.hosts | join "," | trimAll ",") $ingress_hosts | splitList "," | uniq | join ",") }}
+{{- $all_hosts := empty $allowed_hosts | ternary $ingress_hosts (printf "%v,%v" $allowed_hosts $ingress_hosts | splitList "," | uniq | join ",") }}
 {{- $all_hosts_client := empty $allowed_hosts | ternary $ingress_hosts_client ($all_hosts | replace "core." "" | splitList "," | uniq | join ",") }}
 
 apiVersion: v1
@@ -87,7 +87,6 @@ data:
   GUNICORN_LOG_LEVEL: {{ .Values.api.gunicorn.log_level | quote }}
   GUNICORN_FORWARDED_ALLOW_IPS: {{ .Values.api.gunicorn.forwarded_allow_ips | quote }}
   GUNICORN_PROXY_ALLOW_IPS: {{ .Values.api.gunicorn.proxy_allow_ips | quote }}
-  GUNICORN_BIND_TEST_TEST_TEST_TEST: {{ .Values.api.gunicorn.host | quote }}
   GUNICORN_BIND_HOST: {{ .Values.api.gunicorn.host | quote }}
   GUNICORN_BIND_PORT: {{ .Values.api.gunicorn.port | quote }}
   GUNICORN_BACKLOG: {{ .Values.api.gunicorn.backlog | quote }}
@@ -161,3 +160,16 @@ data:
   BRAINTREE_REQUIRE_3D_SECURE: {{ .Values.externalServices.braintree.require3DSecure | quote }}
 {{- end }}
 
+
+  ### Restic backups
+{{- if or .Values.backup.database.enabled .Values.backup.media.enabled }}
+{{- if .Values.backup.restic.s3.repositoryUrlOverride }}
+  RESTIC_REPOSITORY: {{ .Values.backup.restic.s3.repositoryUrlOverride | quote }}
+{{- else }}
+  RESTIC_REPOSITORY: {{ printf "s3:https://%v/%v" .Values.backup.restic.s3.endpointUrl .Values.backup.restic.s3.bucketName }}
+{{- end }}
+  RESTIC_S3_REGION: {{ .Values.backup.restic.s3.region | quote }}
+  RESTIC_GLOBAL_ARGS: {{ .Values.backup.restic.additionalGlobalArgs | quote }}
+  RESTIC_HOST: {{ .Values.backup.restic.hostname | quote }}
+  POSTGRESQL_ADDITIONAL_ARGS: {{ .Values.backup.database.additionalArgs | quote }}
+{{- end }}

--- a/charts/saleor-core/templates/deployment-api.yaml
+++ b/charts/saleor-core/templates/deployment-api.yaml
@@ -15,9 +15,12 @@ spec:
       app.kubernetes.io/component: api
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+      {{- if not .Values.alternativeAppSettingsConfigMap }}
+        checksum/config-settings: {{ include (print $.Template.BasePath "/configmap-settings.yaml") . | sha256sum }}
+      {{- end }}
+      {{- with .Values.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
         {{- include "saleor-core.selectorLabels" . | nindent 8 }}
@@ -36,21 +39,21 @@ spec:
         - name: custom-settings
           configMap:
           {{- if (not .Values.alternativeAppSettingsConfigMap) }}
-            name: {{ include "saleor-core.fullname" . }}-custom-settings
+          name: {{ include "saleor-core.fullname" . }}-custom-settings
           {{- else }}
-            name: {{ .Values.alternativeAppSettingsConfigMap }}
+          name: {{ .Values.alternativeAppSettingsConfigMap }}
           {{- end }}
         # Volume for the images and unstructured data
         - name: saleor-data-media
         {{- if and .Values.persistence.enabled .Values.persistence.existingPvc }}
-          persistentVolumeClaim:
-            claimName: {{ .Values.persistence.existingPvc }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.existingPvc }}
         {{- else if .Values.persistence.enabled }}
-          persistentVolumeClaim:
-            claimName: {{ default (include "saleor-core.fullname" .) }}
+        persistentVolumeClaim:
+          claimName: {{ default (include "saleor-core.fullname" .) }}
         {{- else }}
-          emptyDir:
-            medium: Memory
+        emptyDir:
+          medium: Memory
         {{- end }}
       initContainers:
         # Wait for successful response from redis and postgresql

--- a/charts/saleor-core/templates/deployment-web.yaml
+++ b/charts/saleor-core/templates/deployment-web.yaml
@@ -17,9 +17,13 @@ spec:
       app.kubernetes.io/component: web
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        checksum/config-web: {{ include (print $.Template.BasePath "/configmap-web.yaml") . | sha256sum }}
+      {{- if not .Values.alternativeAppSettingsConfigMap }}
+      checksum/config-settings: {{ include (print $.Template.BasePath "/configmap-settings.yaml") . | sha256sum }}
+      {{- end }}
+      {{- with .Values.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
         {{- include "saleor-core.selectorLabels" . | nindent 8 }}
@@ -38,21 +42,21 @@ spec:
         - name: custom-settings
           configMap:
           {{- if (not .Values.alternativeAppSettingsConfigMap) }}
-            name: {{ include "saleor-core.fullname" . }}-custom-settings
+          name: {{ include "saleor-core.fullname" . }}-custom-settings
           {{- else }}
-            name: {{ .Values.alternativeAppSettingsConfigMap }}
+          name: {{ .Values.alternativeAppSettingsConfigMap }}
           {{- end }}
         # Volume for the images and unstructured data
         - name: saleor-data-media
         {{- if and .Values.persistence.enabled .Values.persistence.existingPvc }}
-          persistentVolumeClaim:
-            claimName: {{ .Values.persistence.existingPvc }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.existingPvc }}
         {{- else if .Values.persistence.enabled }}
-          persistentVolumeClaim:
-            claimName: {{ default (include "saleor-core.fullname" .) }}
+        persistentVolumeClaim:
+          claimName: {{ default (include "saleor-core.fullname" .) }}
         {{- else }}
-          emptyDir:
-            medium: Memory
+        emptyDir:
+          medium: Memory
         {{- end }}
         # ConfigMap for the nginx configuration and the static assets script
         - name: web-conf
@@ -60,8 +64,8 @@ spec:
             name: {{ include "saleor-core.fullname" . }}-web
         # Volume for the web assets data
         - name: saleor-data-static
-          emptyDir:
-            medium: Memory
+        emptyDir:
+          medium: Memory
       initContainers:
         # Wait for redis and postgresql to be ready
         - name: "{{- include "saleor-core.webContainerName" . }}-init-1"
@@ -124,11 +128,11 @@ spec:
               protocol: TCP
           livenessProbe: {{ toYaml .Values.web.livenessProbeSettings | nindent 12 }}
             httpGet:
-              path: /healthz
+              path: /static/images/placeholder60x60.png
               port: {{ int .Values.web.port | add1 }}
           readinessProbe: {{ toYaml .Values.web.readinessProbeSettings | nindent 12 }}
             httpGet:
-              path: /static/images/placeholder60x60.png
+              path: /healthz
               port:  {{ int .Values.web.port | add1 }}
           resources:
             {{- toYaml .Values.web.resources | nindent 12 }}
@@ -144,4 +148,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-{{- end }}
+  {{- end }}

--- a/charts/saleor-core/templates/deployment-worker.yaml
+++ b/charts/saleor-core/templates/deployment-worker.yaml
@@ -16,9 +16,13 @@ spec:
       app.kubernetes.io/component: worker
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        checksum/config-web: {{ include (print $.Template.BasePath "/configmap-web.yaml") . | sha256sum }}
+      {{- if not .Values.alternativeAppSettingsConfigMap }}
+        checksum/config-settings: {{ include (print $.Template.BasePath "/configmap-settings.yaml") . | sha256sum }}
+      {{- end }}
+      {{- with .Values.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
         {{- include "saleor-core.selectorLabels" . | nindent 8 }}
@@ -37,9 +41,9 @@ spec:
         - name: custom-settings
           configMap:
           {{- if (not .Values.alternativeAppSettingsConfigMap) }}
-            name: {{ include "saleor-core.fullname" . }}-custom-settings
+          name: {{ include "saleor-core.fullname" . }}-custom-settings
           {{- else }}
-            name: {{ .Values.alternativeAppSettingsConfigMap }}
+          name: {{ .Values.alternativeAppSettingsConfigMap }}
           {{- end }}
         # ConfigMap for the nginx configuration and the static assets script
         - name: web-conf
@@ -48,14 +52,14 @@ spec:
         # Volume for the images and unstructured data
         - name: saleor-data-media
         {{- if and .Values.persistence.enabled .Values.persistence.existingPvc }}
-          persistentVolumeClaim:
-            claimName: {{ .Values.persistence.existingPvc }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.existingPvc }}
         {{- else if .Values.persistence.enabled }}
-          persistentVolumeClaim:
-            claimName: {{ default (include "saleor-core.fullname" .) }}
+        persistentVolumeClaim:
+          claimName: {{ default (include "saleor-core.fullname" .) }}
         {{- else }}
-          emptyDir:
-            medium: Memory
+        emptyDir:
+          medium: Memory
         {{- end }}
         # Volume for the web assets data
         - name: saleor-data-static
@@ -125,18 +129,18 @@ spec:
             - --heartbeat-interval={{ .Values.worker.heartBeatIntervalSeconds }}
             - --loglevel={{ .Values.worker.logLevel }}
           {{- if (eq (.Values.worker.concurrency.type) "fixed") }}
-            - --concurrency={{ .Values.worker.concurrency.fixed }}
+          - --concurrency={{ .Values.worker.concurrency.fixed }}
           {{- else if (eq (.Values.worker.concurrency.type) "auto") }}
-            - --autoscale={{ .Values.worker.concurrency.autoMaximum }},{{ .Values.worker.concurrency.autoMinimum }}
+          - --autoscale={{ .Values.worker.concurrency.autoMaximum }},{{ .Values.worker.concurrency.autoMinimum }}
           {{- end }}
           {{- if (.Values.worker.hardTimeLimitSeconds) }}
-            - --time-limit={{ .Values.worker.hardTimeLimitSeconds }}
+          - --time-limit={{ .Values.worker.hardTimeLimitSeconds }}
           {{- end }}
           {{- if (.Values.worker.softTimeLimitSeconds) }}
-            - --soft-time-limit={{ .Values.worker.softTimeLimitSeconds }}
+          - --soft-time-limit={{ .Values.worker.softTimeLimitSeconds }}
           {{- end }}
           {{- if (eq .Values.worker.taskEventsMonitoring.enabled true) }}
-            - --task-events
+          - --task-events
           {{- end }}
           # Disabled by default due to issues with failures that need to be worked out
           {{- if .Values.worker.livenessProbeSettings.enabled }}
@@ -148,9 +152,9 @@ spec:
                 - >-
                 {{- if (eq .Values.worker.autoscaling.enabled false) }}
                 # This liveness probe is only suitable if autoscaling is turned off as it can trigger upscaling
-                  'if [[ "$(celery --app=saleor.celeryconf:app inspect ping | grep pong)" == *"pong"* ]]; then exit 0; else exit 1; fi && echo "ready"'
+                'if [[ "$(celery --app=saleor.celeryconf:app inspect ping | grep pong)" == *"pong"* ]]; then exit 0; else exit 1; fi && echo "ready"'
                 {{- else if (eq .Values.worker.autoscaling.enabled true) }}
-                  'echo "ready"'
+                'echo "ready"'
                 {{- end }}
           {{- end }}
           # Disabled by default due to issues with failures that need to be worked out
@@ -163,9 +167,9 @@ spec:
                 - >-
                 {{- if (eq .Values.worker.autoscaling.enabled false) }}
                 # This liveness probe is only suitable if autoscaling is turned off as it can trigger upscaling
-                  'if [[ "$(celery --app=saleor.celeryconf inspect ping | grep pong)" == *"pong"* ]]; then exit 0; else exit 1; fi && echo "ready"'
+                'if [[ "$(celery --app=saleor.celeryconf inspect ping | grep pong)" == *"pong"* ]]; then exit 0; else exit 1; fi && echo "ready"'
                 {{- else if (eq .Values.worker.autoscaling.enabled true) }}
-                  'echo "ready"'
+                'echo "ready"'
                 {{- end }}
           {{- end }}
           resources:

--- a/charts/saleor-core/templates/jobs/05-empty-job.yaml
+++ b/charts/saleor-core/templates/jobs/05-empty-job.yaml
@@ -60,5 +60,5 @@ spec:
             - /bin/bash
             - -c
             - >-
-              sleep 280s
+              sleep {{ $thisJob.jobDuration }}
 {{- end }}

--- a/charts/saleor-core/templates/secret.yaml
+++ b/charts/saleor-core/templates/secret.yaml
@@ -72,6 +72,15 @@ data:
 {{- end }}
 
 
+{{- if or .Values.backup.database.enabled .Values.backup.media.enabled }}
+{{- if .Values.backup.restic.password }}
+  RESTIC_PASSWORD: {{ .Values.backup.restic.password | b64enc | quote }}
+else
+  RESTIC_PASSWORD: {{ (randAlphaNum 12) | b64enc | quote }}
+{{- end }}
+{{- end }}
+
+
 {{- if and (eq .Values.jobs.init.createUsers.enabled true) (gt (len .Values.jobs.init.createUsers.users) 0) -}}
 {{- range $user := .Values.jobs.init.createUsers.users -}}
 {{ $key := cat (splitList "." ($user.email | upper | snakecase | replace "@" "_") | first) "pass" | replace " " "_" }}

--- a/charts/saleor-core/values.yaml
+++ b/charts/saleor-core/values.yaml
@@ -448,3 +448,52 @@ jobs:
       backOffLimit: 1
       ttlSecondsAfterFinished: 120
       weight: 5
+      jobDuration: 60s
+
+## Backup settings
+
+backup:
+  ## If database backups are enabled, it will perform a simple pg_dump on the postgresql database
+  database:
+    enabled: false
+    additionalArgs: "--verbose --data-only --blobs "
+
+  ## If media backups are enabled, it will perform a tar operation of the /app/media directory
+  ## Not to be enabled if using cloudstorage enabled backends
+  media:
+    enabled: false
+
+  ## Upload to s3 configuration using restic. For now only, s3 compliant storage api is supported.
+  restic:
+    # Set the password using a secret called RESTIC_PASSWORD
+    password:
+    additionalGlobalArgs: "--no-cache --verbose "
+    hostname: "saleor-k8s"
+    s3:
+      # Set the s3 key id as RESTIC_S3_ACCESS_KEY_ID in a secret
+      keyId:
+      # Set the s3 secret key as RESTIC_S3_SECRET_ACCESS_KEY in a secret
+      keySecret:
+      endpointUrl:
+      region: "eu-west-1"
+      bucketName:
+      # Set repositoryUrlOverride to set the full s3 repository url manually
+      repositoryUrlOverride:
+
+  cron:
+    enabled: false
+    schedule: "0 6 * * *"
+
+  podSecurityContext:
+    runAsNonRoot: false
+    runAsUser: 0
+    runAsGroup: 0
+    fsGroup: 0
+
+  containerSecurityContext:
+    runAsNonRoot: false
+    allowPrivilegeEscalation: false
+    # capabilities:
+    #   drop:
+    #     - ALL
+    # readOnlyRootFilesystem: true

--- a/charts/saleor-dashboard/Chart.yaml
+++ b/charts/saleor-dashboard/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 name: saleor-dashboard
 description: A Helm chart for deploying the saleor dashboard application in Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 2.11.1
 kubeVersion: ">=1.9.0"
 keywords:

--- a/charts/saleor-platform/Chart.yaml
+++ b/charts/saleor-platform/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 name: saleor-platform
 description: A Helm chart for deploying the entire umbrella of saleor charts
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 2.11.1
 kubeVersion: ">=1.9.0"
 keywords:
@@ -54,7 +54,7 @@ dependencies:
   ## 2. Pods for the web server (for static assets and media assets) if not using cloud storage
   ## 3. Pods for the celery workers which execute particular tasks on demand
   - name: saleor-core
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "https://eirenauts.github.io/saleor-k8s"
     condition: saleor-core.enabled
     tags:
@@ -64,7 +64,7 @@ dependencies:
 
   ## Notes: This is a web server of pre-built static assets and emails for the storefront which customers see
   - name: saleor-storefront
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "https://eirenauts.github.io/saleor-k8s"
     condition: saleor-storefront.enabled
     tags:
@@ -73,7 +73,7 @@ dependencies:
 
   ## Notes: This is a web server of pre-built static assets for the administrative dashboard
   - name: saleor-dashboard
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "https://eirenauts.github.io/saleor-k8s"
     condition: saleor-dashboard.enabled
     tags:

--- a/charts/saleor-storefront/Chart.yaml
+++ b/charts/saleor-storefront/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 name: saleor-storefront
 description: A Helm chart for deploying the saleor storefront application in Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 2.11.1
 kubeVersion: ">=1.9.0"
 keywords:

--- a/example/playbooks/install-saleor.yaml
+++ b/example/playbooks/install-saleor.yaml
@@ -64,7 +64,7 @@
           community.kubernetes.helm:
             atomic: false
             chart_ref: saleor-k8s/saleor-platform
-            chart_version: 0.1.0
+            chart_version: 0.1.1
             wait: true
             wait_timeout: 20m0s
             release_name: saleor-platform

--- a/images/Core.Dev.Dockerfile
+++ b/images/Core.Dev.Dockerfile
@@ -65,7 +65,7 @@ RUN \
     apt-get update -y && \
     apt-get install -y --no-install-recommends --allow-downgrades \
       libxml2='2.9.4+dfsg1-7+deb10u2' \
-      libssl1.1='1.1.1d-0+deb10u3' \
+      libssl1.1='1.1.1d-0+deb10u6' \
       libcairo2='1.16.0-4' \
       libpango-1.0-0='1.42.4-8~deb10u1' \
       libpangocairo-1.0-0='1.42.4-8~deb10u1' \

--- a/images/Core.Dev.Dockerfile
+++ b/images/Core.Dev.Dockerfile
@@ -38,8 +38,8 @@ ENV \
     # Restic configuration
     RESTIC_DOWNLOAD_URL=https://github.com/restic/restic/releases/download \
     RESTIC_VERSION=0.11.0 \
-    RESTIC_PASSWORD="" \
-    RESTIC_REPOSITORY="/restic-data/restic-repo"
+    RESTIC_PASSWORD="${RESTIC_PASSWORD:-}" \
+    RESTIC_REPOSITORY="${RESTIC_REPOSITORY:-}"
 
 LABEL \
     \
@@ -64,7 +64,7 @@ RUN \
     \
     apt-get update -y && \
     apt-get install -y --no-install-recommends --allow-downgrades \
-      libxml2='2.9.4+dfsg1-7+deb10u1' \
+      libxml2='2.9.4+dfsg1-7+deb10u2' \
       libssl1.1='1.1.1d-0+deb10u3' \
       libcairo2='1.16.0-4' \
       libpango-1.0-0='1.42.4-8~deb10u1' \
@@ -106,8 +106,8 @@ RUN \
     useradd --uid "${UID}" --gid "${GUID}" --create-home saleor && \
     mkdir -p /app/media /app/static && \
     chown -R "${UID}:0" /app && \
-    mkdir -p "${RESTIC_REPOSITORY}" && \
-    chown -R "${UID}:0" "/$(echo "${RESTIC_REPOSITORY}" | cut -d "/" -f2)"
+    mkdir -p /restic-data/restic-repo && \
+    chown -R "${UID}:0" "/$(echo /restic-data/restic-repo | cut -d "/" -f2)"
 
 USER "${UID}"
 EXPOSE 8000

--- a/images/Core.Dev.Dockerfile
+++ b/images/Core.Dev.Dockerfile
@@ -82,7 +82,7 @@ RUN \
       tee /etc/apt/sources.list.d/pgdg.list && \
     apt-get update -y && \
     apt-get install -y --no-install-recommends \
-      postgresql-client-12='12.5-1.pgdg100+1' \
+      postgresql-client-12='12.7-1.pgdg100+1' \
       redis-tools='5:5.0.3-4+deb10u2' && \
     apt-get install -y --no-install-recommends \
         bzip2='1.0.6-9.2~deb10u1' && \

--- a/images/Core.Dev.Dockerfile
+++ b/images/Core.Dev.Dockerfile
@@ -70,7 +70,7 @@ RUN \
       libpango-1.0-0='1.42.4-8~deb10u1' \
       libpangocairo-1.0-0='1.42.4-8~deb10u1' \
       libgdk-pixbuf2.0-0='2.38.1+dfsg-1' \
-      libmagic1='1:5.35-4+deb10u1' \
+      libmagic1='1:5.35-4+deb10u2' \
       shared-mime-info='1.10-1' \
       mime-support='3.62' && \
     apt-get install -y --no-install-recommends \

--- a/images/Core.Dev.Dockerfile
+++ b/images/Core.Dev.Dockerfile
@@ -66,7 +66,7 @@ RUN \
     apt-get install -y --no-install-recommends --allow-downgrades \
       libxml2='2.9.4+dfsg1-7+deb10u2' \
       libssl1.1='1.1.1d-0+deb10u6' \
-      libcairo2='1.16.0-4' \
+      libcairo2='1.16.0-4+deb10u1' \
       libpango-1.0-0='1.42.4-8~deb10u1' \
       libpangocairo-1.0-0='1.42.4-8~deb10u1' \
       libgdk-pixbuf2.0-0='2.38.1+dfsg-1' \

--- a/images/Core.Dockerfile
+++ b/images/Core.Dockerfile
@@ -59,7 +59,7 @@ RUN \
     apt-get install -y --no-install-recommends --allow-downgrades \
       libxml2='2.9.4+dfsg1-7+deb10u2' \
       libssl1.1='1.1.1d-0+deb10u6' \
-      libcairo2='1.16.0-4' \
+      libcairo2='1.16.0-4+deb10u1' \
       libpango-1.0-0='1.42.4-8~deb10u1' \
       libpangocairo-1.0-0='1.42.4-8~deb10u1' \
       libgdk-pixbuf2.0-0='2.38.1+dfsg-1' \

--- a/images/Core.Dockerfile
+++ b/images/Core.Dockerfile
@@ -63,7 +63,7 @@ RUN \
       libpango-1.0-0='1.42.4-8~deb10u1' \
       libpangocairo-1.0-0='1.42.4-8~deb10u1' \
       libgdk-pixbuf2.0-0='2.38.1+dfsg-1' \
-      libmagic1='1:5.35-4+deb10u1' \
+      libmagic1='1:5.35-4+deb10u2' \
       shared-mime-info='1.10-1' \
       mime-support='3.62' && \
     apt-get clean && \

--- a/images/Core.Dockerfile
+++ b/images/Core.Dockerfile
@@ -57,7 +57,7 @@ SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 RUN \
     apt-get update -y && \
     apt-get install -y --no-install-recommends --allow-downgrades \
-      libxml2='2.9.4+dfsg1-7+deb10u1' \
+      libxml2='2.9.4+dfsg1-7+deb10u2' \
       libssl1.1='1.1.1d-0+deb10u3' \
       libcairo2='1.16.0-4' \
       libpango-1.0-0='1.42.4-8~deb10u1' \

--- a/images/Core.Dockerfile
+++ b/images/Core.Dockerfile
@@ -58,7 +58,7 @@ RUN \
     apt-get update -y && \
     apt-get install -y --no-install-recommends --allow-downgrades \
       libxml2='2.9.4+dfsg1-7+deb10u2' \
-      libssl1.1='1.1.1d-0+deb10u3' \
+      libssl1.1='1.1.1d-0+deb10u6' \
       libcairo2='1.16.0-4' \
       libpango-1.0-0='1.42.4-8~deb10u1' \
       libpangocairo-1.0-0='1.42.4-8~deb10u1' \

--- a/scripts/make.sh
+++ b/scripts/make.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-# shellcheck shell=bash disable=SC1094
-# shellcheck shell=bash disable=SC1090
+# shellcheck shell=bash disable=SC1090,SC1091,SC1094
 
 set -e
 set -o pipefail

--- a/scripts/template_single_file.sh
+++ b/scripts/template_single_file.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# shellcheck disable=SC2086
+
+set -o pipefail
+
+function validate_args() {
+    local filename="${1}"
+    local chart_dir="${2}"
+    local values_filepath="${3}"
+    local release_name="${4}"
+    local namespace="${5}"
+    local set_additional_values="${6}"
+
+    if [[ -z "${filename}" ]]; then
+        echo "filename is required" >>/dev/stderr
+        return
+    fi
+
+    if [[ -z "${chart_dir}" ]]; then
+        echo "chart_dir is required" >>/dev/stderr
+        return
+    fi
+
+    if [[ -z "${values_filepath}" ]]; then
+        echo "values_filepath is required" >>/dev/stderr
+        return
+    fi
+
+    if [[ -z "${release_name}" ]]; then
+        echo "release_name is required" >>/dev/stderr
+        return
+    fi
+
+    if [[ -z "${namespace}" ]]; then
+        echo "namespace is required" >>/dev/stderr
+        return
+    fi
+
+    if [[ -z "${set_additional_values}" ]]; then
+        echo "set_additional_values is required" >>/dev/stderr
+        return
+    fi
+}
+
+# Example usage:
+# template_single_file backup-job.yaml charts/saleor-core values/saleor-core.yaml saleor-platform
+function template_single_file() {
+    local filename="${1}"
+    local chart_dir="${2}"
+    local values_filepath="${3}"
+    local release_name="${4}"
+    local namespace="${5}"
+    local set_additional_values="${6}"
+
+    helm template \
+        --release-name "${release_name}" \
+        --namespace "${namespace}" \
+        ${set_additional_values} \
+        "${chart_dir}" \
+        --values "${values_filepath}" |
+        awk "/${filename}/,/---/" |
+        awk 'NR>2 {print last} {last=$0}'
+}
+
+function main() {
+    local filename="${1}"
+    local chart_dir="${2}"
+    local values_filepath="${3}"
+    local release_name="${4}"
+    local namespace="${5}"
+    local set_additional_values="${6}"
+
+    validate_args \
+        "${filename}" \
+        "${chart_dir}" \
+        "${values_filepath}" \
+        "${release_name}" \
+        "${namespace}" \
+        "${set_additional_values}"
+
+    template_single_file \
+        "${filename}" \
+        "${chart_dir}" \
+        "${values_filepath}" \
+        "${release_name}" \
+        "${namespace}" \
+        "${set_additional_values}"
+}
+
+if [[ "$0" == "${BASH_SOURCE[0]}" ]]; then
+    main "${@}"
+fi


### PR DESCRIPTION
***What does this change do?***

- Added ability to execute backups as a standalone job
- Added ability to execute backups as a cronjob
- Backups leverage existing technology in [RESTIC](https://restic.net/) and a S3 compliant
object storage backend
- Ability to backup the postgresql DB and ability to backup the file system with data files
- Some minor fixes for default handling of the ingresses in env configmap
- Added ENV variables specific to RESTIC backups
- Added a backup section in `values.yaml` for the helm values file to set the required configuration for the S3 compliant backend
- Minor improvements to CI
- Added a bash function or file which allows for the templating of a single file - This is used for `execute backups as a standalone job`

***Why is this change needed?***

- Facilitate backups after saleor has been deployed 